### PR TITLE
Fix docker image name

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 name: restack-engine
 services:
   studio:
-    image: ghcr.io/restackio/local-operator:main
+    image: ghcr.io/restackio/engine:main
     ports:
       - "5233:5233"
       - "6233:6233"

--- a/examples/get-started/readme.md
+++ b/examples/get-started/readme.md
@@ -1,5 +1,5 @@
 # Run Restack in Docker
-docker run -d --pull always --name studio -p 5233:5233 -p 6233:6233 -p 7233:7233 ghcr.io/restackio/local-operator:main
+docker run -d --pull always --name studio -p 5233:5233 -p 6233:6233 -p 7233:7233 ghcr.io/restackio/engine:main
 
 # Open the Desktop UI
 http://localhost:5233

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ Restack Engine will run locally in the application
 
 # Alternative run Restack in Docker
 
-docker run -d --pull always --name studio -p 5233:5233 -p 6233:6233 -p 7233:7233 ghcr.io/restackio/local-operator:main
+docker run -d --pull always --name studio -p 5233:5233 -p 6233:6233 -p 7233:7233 ghcr.io/restackio/engine:main
 
 or
 


### PR DESCRIPTION
Changes the image name where was still left from `local-operator` to `engine`