### PR TITLE
Revert .gitignore in get-started

### DIFF
--- a/examples/get-started/.gitignore
+++ b/examples/get-started/.gitignore
@@ -1,7 +1,0 @@
-node_modules
-dist
-.env
-.env*
-.npmrc
-tsconfig.tsbuildinfo
-.DS_Store

--- a/examples/get-started/bin/get-started.ts
+++ b/examples/get-started/bin/get-started.ts
@@ -32,7 +32,7 @@ async function main() {
 
   if (projectName) {
     targetDir = path.join(currentDir, projectName);
-    const filesToCopy = ['src', 'scheduleWorkflow.ts', 'tsconfig.json', '.gitignore'];
+    const filesToCopy = ['src', 'scheduleWorkflow.ts', 'tsconfig.json'];
     filesToCopy.forEach(file => {
       fs.cpSync(path.join(packageRoot, file), path.join(targetDir, file), { recursive: true });
     });

--- a/examples/get-started/package.json
+++ b/examples/get-started/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@restackio/get-started",
-    "version": "1.0.11",
+    "version": "1.0.12",
     "description": "Get started with Restack AI SDK",
     "bin": {
         "get-started": "bin/get-started.mjs"
@@ -9,7 +9,6 @@
         "bin",
         "src",
         "scheduleWorkflow.ts",
-        ".gitignore",
         "readme.md",
         "tsconfig.json"
     ],


### PR DESCRIPTION
Npm magically renames `.gitignore` to `.npmignore`, so this functionality doesn't work.
https://github.com/npm/cli/issues/5756
This will be fixed when we `git clone @restackio/hello-world` in the script, instead of two-in-one package as of now.