### PR TITLE
Add CA package

### DIFF
--- a/examples/composio/Dockerfile
+++ b/examples/composio/Dockerfile
@@ -27,6 +27,10 @@ RUN npm run build
 
 FROM node:20-bullseye-slim AS runner
 
+RUN apt-get update \
+  && apt-get install -y ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
 RUN addgroup --system --gid 1001 service
 RUN adduser --system --uid 1001 service
 USER service

--- a/examples/gemini/Dockerfile
+++ b/examples/gemini/Dockerfile
@@ -27,6 +27,10 @@ RUN npm run build
 
 FROM node:20-bullseye-slim AS runner
 
+RUN apt-get update \
+  && apt-get install -y ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
 RUN addgroup --system --gid 1001 service
 RUN adduser --system --uid 1001 service
 USER service

--- a/examples/openai/Dockerfile
+++ b/examples/openai/Dockerfile
@@ -27,6 +27,10 @@ RUN npm run build
 
 FROM node:20-bullseye-slim AS runner
 
+RUN apt-get update \
+  && apt-get install -y ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
 RUN addgroup --system --gid 1001 service
 RUN adduser --system --uid 1001 service
 USER service

--- a/examples/posthog/Dockerfile
+++ b/examples/posthog/Dockerfile
@@ -27,6 +27,10 @@ RUN npm run build
 
 FROM node:20-bullseye-slim AS runner
 
+RUN apt-get update \
+  && apt-get install -y ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
 RUN addgroup --system --gid 1001 service
 RUN adduser --system --uid 1001 service
 USER service

--- a/examples/voice/Dockerfile.services
+++ b/examples/voice/Dockerfile.services
@@ -27,6 +27,10 @@ RUN npm run build
 
 FROM node:20-bullseye-slim AS runner
 
+RUN apt-get update \
+  && apt-get install -y ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
 RUN addgroup --system --gid 1001 service
 RUN adduser --system --uid 1001 service
 USER service


### PR DESCRIPTION
Adds CA package to end docker image, so Worker can connect to engine.restack.io, otherwise throws `InvalidCertificate(UnknownIssuer)`