### PR TITLE
Update examples to use gpt-4.1-mini

### DIFF
--- a/agent-apis/src/functions/llm.ts
+++ b/agent-apis/src/functions/llm.ts
@@ -14,7 +14,7 @@ export type OpenAIChatInput = {
 export const llm = async ({
   userContent,
   systemContent = "",
-  model = "gpt-4o-mini",
+  model = "gpt-4.1-mini",
 }: OpenAIChatInput): Promise<string> => {
   try {
     const openai = new OpenAI({

--- a/agent-rag/src/functions/llmChat.ts
+++ b/agent-rag/src/functions/llmChat.ts
@@ -21,7 +21,7 @@ export type OpenAIChatInput = {
 
 export const llmChat = async ({
   systemContent = "",
-  model = "gpt-4o-mini",
+  model = "gpt-4.1-mini",
   messages,
 }: OpenAIChatInput): Promise<string> => {
   try {

--- a/agent-reactflow/apps/backend/src/functions/llmChat.ts
+++ b/agent-reactflow/apps/backend/src/functions/llmChat.ts
@@ -19,7 +19,7 @@ export type OpenAIChatInput = {
 
 export const llmChat = async ({
   systemContent = "",
-  model = "gpt-4o",
+  model = "gpt-4.1-mini",
   messages,
   stream = true,
   tools,

--- a/agent-reactflow/apps/backend/src/functions/llmResponse.ts
+++ b/agent-reactflow/apps/backend/src/functions/llmResponse.ts
@@ -27,7 +27,7 @@ export const llmResponse = async ({
 
     const chatParams: ChatCompletionCreateParamsNonStreaming = {
       messages: messages,
-      model: "gpt-4o-mini",
+      model: "gpt-4.1-mini",
       response_format: responseFormat,
     };
 

--- a/agent-reactflow/apps/frontend/app/api/chat/route.ts
+++ b/agent-reactflow/apps/frontend/app/api/chat/route.ts
@@ -16,7 +16,7 @@ export async function POST(req: Request) {
   })
 
   const result = streamText({
-    model: openaiClient('gpt-4o'),
+    model: openaiClient('gpt-4.1-mini'),
     messages,
     tools: {
       updateFlow: tool({

--- a/agent-stream/src/functions/llmChat.ts
+++ b/agent-stream/src/functions/llmChat.ts
@@ -18,7 +18,7 @@ export type OpenAIChatInput = {
 
 export const llmChat = async ({
   systemContent = "",
-  model = "gpt-4o-mini",
+  model = "gpt-4.1-mini",
   messages,
   stream = true,
 }: OpenAIChatInput): Promise<Message> => {

--- a/agent-telephony/twilio-livekit/agent/src/functions/llmLogic.ts
+++ b/agent-telephony/twilio-livekit/agent/src/functions/llmLogic.ts
@@ -47,7 +47,7 @@ export const llmLogic = async ({
 
       const completion = await openai.beta.chat.completions.parse({
         messages,
-        model: "gpt-4o",
+        model: "gpt-4.1-mini",
         response_format: zodResponseFormat(LlmLogicResponse, "logic"),
       });
 

--- a/agent-telephony/twilio-livekit/readme.md
+++ b/agent-telephony/twilio-livekit/readme.md
@@ -31,7 +31,7 @@ docker run -d --pull always --name restack -p 5233:5233 -p 6233:6233 -p 7233:723
 
 In all subfolders, duplicate the `env.example` file and rename it to `.env`.
 
-Obtain a Restack API Key to interact with the 'gpt-4o-mini' model at no cost from [Restack Cloud](https://console.restack.io/starter)
+Obtain a Restack API Key to interact with the 'gpt-4.1-mini' model at no cost from [Restack Cloud](https://console.restack.io/starter)
 
 
 ## Install dependencies and start services

--- a/agent-todo/src/functions/llmChat.ts
+++ b/agent-todo/src/functions/llmChat.ts
@@ -26,7 +26,7 @@ export type OpenAIChatInput = {
 
 export const llmChat = async ({
   systemContent = "",
-  model = "gpt-4o-mini",
+  model = "gpt-4.1-mini",
   messages,
   tools,
 }: OpenAIChatInput): Promise<ChatCompletionMessage> => {

--- a/agent-tool/src/functions/llmChat.ts
+++ b/agent-tool/src/functions/llmChat.ts
@@ -26,7 +26,7 @@ export type OpenAIChatInput = {
 
 export const llmChat = async ({
   systemContent = "",
-  model = "gpt-4o-mini",
+  model = "gpt-4.1-mini",
   messages,
   tools,
 }: OpenAIChatInput): Promise<ChatCompletionMessage> => {

--- a/agent-voice/livekit/agent/src/functions/llmChat.ts
+++ b/agent-voice/livekit/agent/src/functions/llmChat.ts
@@ -18,7 +18,7 @@ export type OpenAIChatInput = {
 
 export const llmChat = async ({
   systemContent = "",
-  model = "gpt-4o-mini",
+  model = "gpt-4.1-mini",
   messages,
   stream = true,
 }: OpenAIChatInput): Promise<Message> => {

--- a/agent-voice/livekit/readme.md
+++ b/agent-voice/livekit/readme.md
@@ -51,7 +51,7 @@ Your code will be running and syncing with Restack to execute agents.
 
 Duplicate the `env.example` file and rename it to `.env`.
 
-Obtain a Restack API Key to interact with the 'gpt-4o-mini' model at no cost from [Restack Cloud](https://console.restack.io/starter)
+Obtain a Restack API Key to interact with the 'gpt-4.1-mini' model at no cost from [Restack Cloud](https://console.restack.io/starter)
 
 
 ## Interact in realtime with the agent

--- a/features-alpha/encryption/src/functions/openai/chat/completionsBase.ts
+++ b/features-alpha/encryption/src/functions/openai/chat/completionsBase.ts
@@ -25,7 +25,7 @@ export type OpenAIChatInput = {
 export const openaiChatCompletionsBase = async ({
   userContent,
   systemContent = "",
-  model = "gpt-4o-mini",
+  model = "gpt-4.1-mini",
   jsonSchema,
   price,
   apiKey,

--- a/features-alpha/encryption/src/functions/openai/chat/completionsStream.ts
+++ b/features-alpha/encryption/src/functions/openai/chat/completionsStream.ts
@@ -14,7 +14,7 @@ import { SendWorkflowEvent } from "@restackio/ai/event";
 import { ChatModel } from "openai/resources/index";
 
 export async function openaiChatCompletionsStream({
-  model = "gpt-4o-mini",
+  model = "gpt-4.1-mini",
   userName,
   newMessage,
   assistantName,

--- a/features-alpha/encryption/src/functions/openai/thread/createAssistant.ts
+++ b/features-alpha/encryption/src/functions/openai/thread/createAssistant.ts
@@ -8,7 +8,7 @@ export async function createAssistant({
   apiKey,
   name,
   instructions,
-  model = "gpt-4o-mini",
+  model = "gpt-4.1-mini",
   tools = [],
 }: {
   apiKey: string;

--- a/refactor-needed/posthog/readme.md
+++ b/refactor-needed/posthog/readme.md
@@ -2,7 +2,7 @@
 
 We built this to autonomous AI to watch Posthog Session Recording and create a digest on Linear (optional)
 
-Its using OpenAI GPT-4o-mini to analyse recordings.
+Its using OpenAI GPT-4.1-mini to analyse recordings.
 And OpenAI O1-preview to reason and create a digest in Markdown.
 
 By default we retrieve all recodings from last 24 hours, so by scheduling the workflow to run every day we get a digest of all new recordings.

--- a/refactor-needed/posthog/src/functions/openai/chat/completionsBase.ts
+++ b/refactor-needed/posthog/src/functions/openai/chat/completionsBase.ts
@@ -25,7 +25,7 @@ export type OpenAIChatInput = {
 export const openaiChatCompletionsBase = async ({
   userContent,
   systemContent = "",
-  model = "gpt-4o-mini",
+  model = "gpt-4.1-mini",
   jsonSchema,
   price,
   apiKey,

--- a/refactor-needed/posthog/src/functions/openai/chat/completionsStream.ts
+++ b/refactor-needed/posthog/src/functions/openai/chat/completionsStream.ts
@@ -14,7 +14,7 @@ import { SendWorkflowEvent } from "@restackio/ai/event";
 import { ChatModel } from "openai/resources/index";
 
 export async function openaiChatCompletionsStream({
-  model = "gpt-4o-mini",
+  model = "gpt-4.1-mini",
   userName,
   newMessage,
   assistantName,

--- a/refactor-needed/posthog/src/functions/openai/thread/createAssistant.ts
+++ b/refactor-needed/posthog/src/functions/openai/thread/createAssistant.ts
@@ -8,7 +8,7 @@ export async function createAssistant({
   apiKey,
   name,
   instructions,
-  model = "gpt-4o-mini",
+  model = "gpt-4.1-mini",
   tools = [],
 }: {
   apiKey: string;

--- a/refactor-needed/posthog/src/workflows/chunk.ts
+++ b/refactor-needed/posthog/src/workflows/chunk.ts
@@ -46,7 +46,7 @@ export async function chunkWorkflow({
   }).openaiChatCompletionsBase({
     systemContent:
       "You are a helpful assistant that summarizes posthog recordings. Here is the snapshot blob of it",
-    model: "gpt-4o-mini",
+    model: "gpt-4.1-mini",
     userContent: `
       Here is a chunk of the recording blob:
       ${chunk}

--- a/refactor-needed/posthog/src/workflows/recording.ts
+++ b/refactor-needed/posthog/src/workflows/recording.ts
@@ -110,7 +110,7 @@ export async function recordingWorkflow({
   }).openaiChatCompletionsBase({
     systemContent:
       "You are a helpful assistant that summarizes posthog recordings.",
-    model: "gpt-4o-mini",
+    model: "gpt-4.1-mini",
     userContent: `
       Here are summaries of each chunk of the recording blob:
       ${summaries}

--- a/refactor-needed/voice/src/functions/openai/chat/completionsBase.ts
+++ b/refactor-needed/voice/src/functions/openai/chat/completionsBase.ts
@@ -25,7 +25,7 @@ export type OpenAIChatInput = {
 export const openaiChatCompletionsBase = async ({
   userContent,
   systemContent = "",
-  model = "gpt-4o-mini",
+  model = "gpt-4.1-mini",
   jsonSchema,
   price,
   apiKey,

--- a/refactor-needed/voice/src/functions/openai/chat/completionsStream.ts
+++ b/refactor-needed/voice/src/functions/openai/chat/completionsStream.ts
@@ -14,7 +14,7 @@ import { SendWorkflowEvent } from "@restackio/ai/event";
 import { ChatModel } from "openai/resources/index";
 
 export async function openaiChatCompletionsStream({
-  model = "gpt-4o-mini",
+  model = "gpt-4.1-mini",
   userName,
   newMessage,
   assistantName,

--- a/refactor-needed/voice/src/functions/openai/thread/createAssistant.ts
+++ b/refactor-needed/voice/src/functions/openai/thread/createAssistant.ts
@@ -8,7 +8,7 @@ export async function createAssistant({
   apiKey,
   name,
   instructions,
-  model = "gpt-4o-mini",
+  model = "gpt-4.1-mini",
   tools = [],
 }: {
   apiKey: string;

--- a/refactor-needed/voice/src/workflows/conversation/conversation.ts
+++ b/refactor-needed/voice/src/workflows/conversation/conversation.ts
@@ -35,7 +35,7 @@ export async function conversationWorkflow({
       taskQueue: "erp",
     }).erpGetTools();
 
-    const model: ChatModel = "gpt-4o-mini";
+    const model: ChatModel = "gpt-4.1-mini";
 
     const commonOpenaiOptions = {
       model,


### PR DESCRIPTION
Updates the examples to use `gpt-4.1-mini` instead of `gpt-4o` or `gpt-4o-mini` 